### PR TITLE
fix: fallback to root queries directory when path-specific queries none

### DIFF
--- a/build/build_impl.odin
+++ b/build/build_impl.odin
@@ -252,7 +252,12 @@ _install_parser :: proc(opts: Install_Parser_Opts) -> (ok: bool) {
 		}
 	}
 
-	has_queries := cp(filepath.join({pp.tmp_dir, opts.path, "queries"}), filepath.join({parser_dir, "queries"}))
+	// Try to find queries - first at {path}/queries, then fallback to root queries/
+	queries_src := filepath.join({pp.tmp_dir, opts.path, "queries"})
+	if !os.exists(queries_src) && opts.path != "" {
+		queries_src = filepath.join({pp.tmp_dir, "queries"})
+	}
+	has_queries := cp(queries_src, filepath.join({parser_dir, "queries"}))
 
 	buf := strings.builder_make()
 	fmt.sbprintf(&buf, BINDINGS, name)


### PR DESCRIPTION
Some tree-sitter repos like tree-sitter-typescript store multiple parsers in subdirectories (typescript/, tsx/) but share queries at the root level.

This change tries {path}/queries first (preserving existing behavior), then falls back to the root queries/ directory if not found.